### PR TITLE
Add one-click setup for auto-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,29 @@ This project provides an experimental framework for building fully local AI agen
 
 - Works completely offline. Models are expected to be available locally.
 - Simple FAISS index for document retrieval.
-- Example script `rag_assistant.py` that demonstrates question answering over a small set of documents. Conversation logs can optionally be stored in SurrealDB.
+- Text-to-speech output using `pyttsx3`. A British voice is selected by default,
+  but you can specify any installed voice with the `voice_name` argument. Call
+  `list_available_voices()` to see voices detected on your system.
+- Example script `rag_assistant.py` that demonstrates question answering over a
+  small set of documents. Conversation logs can optionally be stored in
+  SurrealDB.
+
+## One-click installation
+
+Run `one_click_setup.sh` on Linux/macOS or `one_click_setup.bat` on Windows to
+create a virtual environment, install dependencies, and register the assistant
+to start automatically whenever you log in. After running the script, the
+assistant launches immediately and will auto-start on reboot.
 
 ## Usage
 
 1. Download the desired Qwen model (for example `Qwen/Qwen-7B-Chat`) and place it in a local directory.
-2. Install dependencies:
+2. Install dependencies (or just run the one-click script):
    ```bash
-   pip install faiss-cpu sentence-transformers transformers pyttsx3
+   pip install -r requirements.txt
    ```
+   Alternatively, execute `./one_click_setup.sh` or `one_click_setup.bat` which
+   will install everything automatically.
 3. Prepare a set of text documents you want the assistant to search through.
 4. Run the example:
    ```bash
@@ -23,6 +37,8 @@ This project provides an experimental framework for building fully local AI agen
    Ask a question and the assistant will respond aloud with a British accent.
    To use a specific installed voice, pass the `voice_name` argument when
    creating `LocalRAGAssistant`, e.g. `LocalRAGAssistant(model_path="Qwen/Qwen-7B-Chat", voice_name="lottie")`.
+   You can also enable the BMAD Method and Evolve 2 workflow with
+   `use_bmad=True` and by passing a custom `Evolve2Workflow` instance.
 
 ## SurrealDB logging
 
@@ -46,6 +62,13 @@ npm start
 ```
 
 The demo uses placeholders for backend calls. Connect it to your local Python assistant or Evolve 2 service as needed.
+
+## BMAD Method and Evolve 2 integration
+
+`workflow_engine.py` includes minimal stubs for the **BMAD Method** and the
+**Evolve 2** workflow engine. Enable these components when creating
+`LocalRAGAssistant` to preprocess input or orchestrate multi-step agent
+behaviors.
 
 
 ## Building executables

--- a/one_click_setup.bat
+++ b/one_click_setup.bat
@@ -1,0 +1,17 @@
+@echo off
+:: Install dependencies, set up autorun, and start the assistant on Windows
+if not exist venv (
+    python -m venv venv
+)
+call venv\Scripts\activate
+pip install --upgrade pip
+pip install -r requirements.txt
+
+:: Create a startup task to run the assistant after login
+schtasks /Query /TN "SamanthaAssistant" >nul 2>&1
+if %ERRORLEVEL% NEQ 0 (
+    schtasks /Create /SC ONLOGON /RL HIGHEST /TN "SamanthaAssistant" ^
+        /TR "\"%CD%\venv\Scripts\python.exe\" \"%CD%\rag_assistant.py\"" /F
+)
+
+call venv\Scripts\python.exe rag_assistant.py

--- a/one_click_setup.sh
+++ b/one_click_setup.sh
@@ -12,7 +12,7 @@ pip install --upgrade pip
 pip install -r requirements.txt
 
 # Add @reboot entry to current user's crontab if missing
-if ! crontab -l 2>/dev/null | grep -q "rag_assistant.py"; then
+if ! crontab -l 2>/dev/null | grep -q "# SamanthaAssistantAutorun"; then
     (crontab -l 2>/dev/null; echo "@reboot $BASE_DIR/venv/bin/python $BASE_DIR/rag_assistant.py") | crontab -
     echo "Added reboot entry to crontab"
 fi

--- a/one_click_setup.sh
+++ b/one_click_setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Install dependencies, set up autorun, and start the assistant
+set -e
+BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$BASE_DIR"
+
+if [ ! -d "venv" ]; then
+    python3 -m venv venv
+fi
+source venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+
+# Add @reboot entry to current user's crontab if missing
+if ! crontab -l 2>/dev/null | grep -q "rag_assistant.py"; then
+    (crontab -l 2>/dev/null; echo "@reboot $BASE_DIR/venv/bin/python $BASE_DIR/rag_assistant.py") | crontab -
+    echo "Added reboot entry to crontab"
+fi
+
+exec "$BASE_DIR/venv/bin/python" rag_assistant.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+faiss-cpu
+sentence-transformers
+transformers
+pyttsx3


### PR DESCRIPTION
## Summary
- document one-click setup scripts in the README
- provide requirements.txt
- add `one_click_setup.sh` and `one_click_setup.bat` for automatic installation and autorun

## Testing
- `python -m py_compile rag_assistant.py surrealdb_client.py video_generator.py workflow_engine.py`


------
https://chatgpt.com/codex/tasks/task_b_683be56d0cb08326852bb1affb850e80